### PR TITLE
update locations of various data archives to most recent versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ shp/03W-attributes.dbf: zip/NHDPlusSA/NHDPlus03W/NHDPlusV21_SA_03W_NHDPlusAttrib
 
 # Great Lakes
 shp/04-geometry.shp: zip/NHDPlusGL/NHDPlusV21_GL_04_NHDSnapshot_07.7z
-shp/04-attributes.dbf: zip/NHDPlusGL/NHDPlusV21_GL_04_NHDPlusAttributes_06.7z
+shp/04-attributes.dbf: zip/NHDPlusGL/NHDPlusV21_GL_04_NHDPlusAttributes_08.7z
 
 # Ohio
 shp/05-geometry.shp: zip/NHDPlusMS/NHDPlus05/NHDPlusV21_MS_05_NHDSnapshot_05.7z
@@ -50,11 +50,11 @@ shp/06-attributes.dbf: zip/NHDPlusMS/NHDPlus06/NHDPlusV21_MS_06_NHDPlusAttribute
 
 # Upper Mississippi
 shp/07-geometry.shp: zip/NHDPlusMS/NHDPlus07/NHDPlusV21_MS_07_NHDSnapshot_04.7z
-shp/07-attributes.dbf: zip/NHDPlusMS/NHDPlus07/NHDPlusV21_MS_07_NHDPlusAttributes_05.7z
+shp/07-attributes.dbf: zip/NHDPlusMS/NHDPlus07/NHDPlusV21_MS_07_NHDPlusAttributes_06.7z
 
 # Lower Mississippi
 shp/08-geometry.shp: zip/NHDPlusMS/NHDPlus08/NHDPlusV21_MS_08_NHDSnapshot_03.7z
-shp/08-attributes.dbf: zip/NHDPlusMS/NHDPlus08/NHDPlusV21_MS_08_NHDPlusAttributes_02.7z
+shp/08-attributes.dbf: zip/NHDPlusMS/NHDPlus08/NHDPlusV21_MS_08_NHDPlusAttributes_03.7z
 
 # Souris-Red-Rainy
 shp/09-geometry.shp: zip/NHDPlusSR/NHDPlusV21_SR_09_NHDSnapshot_04.7z
@@ -66,10 +66,10 @@ shp/10U-attributes.dbf: zip/NHDPlusMS/NHDPlus10U/NHDPlusV21_MS_10U_NHDPlusAttrib
 
 # Lower Missouri
 shp/10L-geometry.shp: zip/NHDPlusMS/NHDPlus10L/NHDPlusV21_MS_10L_NHDSnapshot_05.7z
-shp/10L-attributes.dbf: zip/NHDPlusMS/NHDPlus10L/NHDPlusV21_MS_10L_NHDPlusAttributes_07.7z
+shp/10L-attributes.dbf: zip/NHDPlusMS/NHDPlus10L/NHDPlusV21_MS_10L_NHDPlusAttributes_08.7z
 
 # Ark-Red-White
-shp/11-geometry.shp: zip/NHDPlusMS/NHDPlus11/NHDPlusV21_MS_11_NHDSnapshot_04.7z
+shp/11-geometry.shp: zip/NHDPlusMS/NHDPlus11/NHDPlusV21_MS_11_NHDSnapshot_05.7z
 shp/11-attributes.dbf: zip/NHDPlusMS/NHDPlus11/NHDPlusV21_MS_11_NHDPlusAttributes_03.7z
 
 # Texas
@@ -82,11 +82,11 @@ shp/13-attributes.dbf: zip/NHDPlusRG/NHDPlusV21_RG_13_NHDPlusAttributes_02.7z
 
 # Upper Colorado
 shp/14-geometry.shp: zip/NHDPlusCO/NHDPlus14/NHDPlusV21_CO_14_NHDSnapshot_04.7z
-shp/14-attributes.dbf: zip/NHDPlusCO/NHDPlus14/NHDPlusV21_CO_14_NHDPlusAttributes_03.7z
+shp/14-attributes.dbf: zip/NHDPlusCO/NHDPlus14/NHDPlusV21_CO_14_NHDPlusAttributes_05.7z
 
 # Lower Colorado
 shp/15-geometry.shp: zip/NHDPlusCO/NHDPlus15/NHDPlusV21_CO_15_NHDSnapshot_03.7z
-shp/15-attributes.dbf: zip/NHDPlusCO/NHDPlus15/NHDPlusV21_CO_15_NHDPlusAttributes_02.7z
+shp/15-attributes.dbf: zip/NHDPlusCO/NHDPlus15/NHDPlusV21_CO_15_NHDPlusAttributes_04.7z
 
 # Great Basin
 shp/16-geometry.shp: zip/NHDPlusGB/NHDPlusV21_GB_16_NHDSnapshot_05.7z
@@ -94,7 +94,7 @@ shp/16-attributes.dbf: zip/NHDPlusGB/NHDPlusV21_GB_16_NHDPlusAttributes_02.7z
 
 # Pacific Northwest
 shp/17-geometry.shp: zip/NHDPlusPN/NHDPlusV21_PN_17_NHDSnapshot_04.7z
-shp/17-attributes.dbf: zip/NHDPlusPN/NHDPlusV21_PN_17_NHDPlusAttributes_04.7z
+shp/17-attributes.dbf: zip/NHDPlusPN/NHDPlusV21_PN_17_NHDPlusAttributes_05.7z
 
 # California
 shp/18-geometry.shp: zip/NHDPlusCA/NHDPlusV21_CA_18_NHDSnapshot_04.7z


### PR DESCRIPTION
It appears that once the data files are updated, the older files are removed.  For example, once updated, `NHDPlusV21_MS_10L_NHDPlusAttributes_07.7z` becomes `NHDPlusV21_MS_10L_NHDPlusAttributes_08.7z` and so on.  This change reflects the latest updates and allows of the `make` and `bin/rasterize` commands to run cleanly.